### PR TITLE
Replace [load_template] with [include] to allow local variables

### DIFF
--- a/public/wanna-isotope-shortcode.php
+++ b/public/wanna-isotope-shortcode.php
@@ -152,12 +152,12 @@ class Wanna_Isotope_Shortcode {
                 if( file_exists( get_stylesheet_directory() . '/wanna-isotope/loop.php' ) ) {
         
                     // Load from child theme
-                    load_template( get_stylesheet_directory() . '/wanna-isotope/loop.php', false );
+                    include( get_stylesheet_directory() . '/wanna-isotope/loop.php' );
 
                 } elseif( file_exists( get_template_directory() . '/wanna-isotope/loop.php' ) ) {
         
                     // Load from parent theme
-                    load_template( get_template_directory() . '/wanna-isotope/loop.php', false );
+                    include( get_template_directory() . '/wanna-isotope/loop.php' );
 
                 } else {
                     


### PR DESCRIPTION
Hi! Just found that if you use load_template to load a template, you can't access local variables like $isotope_loop. The most common workaround is to use includes.